### PR TITLE
Support PostgreSQL 12 to 16; fix bug that won't break Korean Hangul into 2-gram

### DIFF
--- a/.github/workflows/postgress12.yml
+++ b/.github/workflows/postgress12.yml
@@ -1,4 +1,4 @@
-name: Build pg_cjk_parser for postgres 12
+name: Build pg_cjk_parser for postgres 12 and 16
 
 on:
   push:
@@ -7,18 +7,42 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-20.04
-
+  build_pg12:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: uninstall postgresql-14
-      run: sudo apt-get remove -y postgresql-14 libpq-dev
-    - name: install dependencies
-      run: sudo apt-get install -y --allow-downgrades postgresql-12 postgresql-server-dev-12 libpq-dev libpq5=12.13-0ubuntu0.20.04.1 gcc icu-devtools libicu-dev
-    - name: make
-      run: make
-    - name: make install
-      run: sudo make install
-    
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          file: Dockerfile_pg12
+          tags: postgres:12-dev
+      -
+        name: Run bash script to verify image postgres:12-dev
+        run: ./postgres-12.sh
+
+  build_pg16:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          file: Dockerfile_pg16
+          tags: postgres:16-dev
+      -
+        name: Run bash script to verify image postgres:16-dev
+        run: ./postgres-16.sh

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -9,43 +9,57 @@ on:
 jobs:
   build_pg12:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
+      - uses: actions/checkout@v4
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
-          push: false
+          push: true
           file: Dockerfile_pg12
-          tags: postgres:12-dev
-      - uses: actions/checkout@v3
+          tags: localhost:5000/postgres:12-dev
       -
         name: Run bash script to verify image postgres:12-dev
-        run: pwd && ls -l && chmod +x ./postgres-12.sh && ./postgres-12.sh
+        run: docker pull localhost:5000/postgres:12-dev && docker tag localhost:5000/postgres:12-dev postgres:12-dev && chmod +x ./postgres-12.sh && ./postgres-12.sh
 
   build_pg16:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
+      - uses: actions/checkout@v4
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
-          push: false
+          push: true
           file: Dockerfile_pg16
-          tags: postgres:16-dev
-      - uses: actions/checkout@v3
+          tags: localhost:5000/postgres:16-dev
       -
         name: Run bash script to verify image postgres:16-dev
-        run: pwd && ls -l  && chmod +x ./postgres-16.sh && ./postgres-16.sh
+        run: docker pull localhost:5000/postgres:6-dev && docker tag localhost:5000/postgres:16-dev postgres:16-dev && chmod +x ./postgres-16.sh && ./postgres-16.sh
 

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -61,5 +61,5 @@ jobs:
           tags: localhost:5000/postgres:16-dev
       -
         name: Run bash script to verify image postgres:16-dev
-        run: docker pull localhost:5000/postgres:6-dev && docker tag localhost:5000/postgres:16-dev postgres:16-dev && chmod +x ./postgres-16.sh && ./postgres-16.sh
+        run: docker pull localhost:5000/postgres:16-dev && docker tag localhost:5000/postgres:16-dev postgres:16-dev && chmod +x ./postgres-16.sh && ./postgres-16.sh
 

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -25,7 +25,7 @@ jobs:
           tags: postgres:12-dev
       -
         name: Run bash script to verify image postgres:12-dev
-        run: pwd && ls -l && chmod +x ./postgres-12.sh && ./postgres-12.sh
+        run: pwd && ls -l .. && chmod +x ../postgres-12.sh && ../postgres-12.sh
 
   build_pg16:
     runs-on: ubuntu-latest
@@ -45,5 +45,5 @@ jobs:
           tags: postgres:16-dev
       -
         name: Run bash script to verify image postgres:16-dev
-        run: pwd && ls -l && chmod +x ./postgres-16.sh && ./postgres-16.sh
+        run: pwd && ls -l .. && chmod +x ../postgres-16.sh && ../postgres-16.sh
 

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -25,7 +25,7 @@ jobs:
           tags: postgres:12-dev
       -
         name: Run bash script to verify image postgres:12-dev
-        run: ./postgres-12.sh
+        run: chmod +x ./postgres-12.sh && ./postgres-12.sh
 
   build_pg16:
     runs-on: ubuntu-latest
@@ -45,4 +45,5 @@ jobs:
           tags: postgres:16-dev
       -
         name: Run bash script to verify image postgres:16-dev
-        run: ./postgres-16.sh
+        run: chmod +x ./postgres-16.sh && ./postgres-16.sh
+

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -23,9 +23,10 @@ jobs:
           push: false
           file: Dockerfile_pg12
           tags: postgres:12-dev
+      - uses: actions/checkout@v3
       -
         name: Run bash script to verify image postgres:12-dev
-        run: pwd && ls -l .. && chmod +x ../postgres-12.sh && ../postgres-12.sh
+        run: pwd && ls -l && chmod +x ./postgres-12.sh && ./postgres-12.sh
 
   build_pg16:
     runs-on: ubuntu-latest
@@ -43,7 +44,8 @@ jobs:
           push: false
           file: Dockerfile_pg16
           tags: postgres:16-dev
+      - uses: actions/checkout@v3
       -
         name: Run bash script to verify image postgres:16-dev
-        run: pwd && ls -l .. && chmod +x ../postgres-16.sh && ../postgres-16.sh
+        run: pwd && ls -l  && chmod +x ./postgres-16.sh && ./postgres-16.sh
 

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -25,7 +25,7 @@ jobs:
           tags: postgres:12-dev
       -
         name: Run bash script to verify image postgres:12-dev
-        run: chmod +x ./postgres-12.sh && ./postgres-12.sh
+        run: pwd && ls -l && chmod +x ./postgres-12.sh && ./postgres-12.sh
 
   build_pg16:
     runs-on: ubuntu-latest
@@ -45,5 +45,5 @@ jobs:
           tags: postgres:16-dev
       -
         name: Run bash script to verify image postgres:16-dev
-        run: chmod +x ./postgres-16.sh && ./postgres-16.sh
+        run: pwd && ls -l && chmod +x ./postgres-16.sh && ./postgres-16.sh
 

--- a/Dockerfile_pg12
+++ b/Dockerfile_pg12
@@ -1,7 +1,7 @@
-FROM postgres:11
+FROM postgres:12
 RUN apt-get update
-RUN apt-get install -y postgresql-server-dev-all
-RUN apt-get install -y gcc
+RUN apt-get install -y postgresql-server-dev-12
+RUN apt-get install -y gcc make
 RUN apt-get install -y icu-devtools libicu-dev
 
 RUN mkdir -p /root/parser

--- a/Dockerfile_pg16
+++ b/Dockerfile_pg16
@@ -1,0 +1,14 @@
+FROM postgres:16
+RUN apt-get update
+RUN apt-get install -y postgresql-server-dev-16
+RUN apt-get install -y gcc make
+RUN apt-get install -y icu-devtools libicu-dev
+
+RUN mkdir -p /root/parser
+WORKDIR /root/parser
+COPY pg_cjk_parser.c /root/parser/
+COPY pg_cjk_parser.control /root/parser/
+COPY Makefile /root/parser/
+COPY pg_cjk_parser--0.0.1.sql /root/parser/
+COPY zht2zhs.h /root/parser/
+RUN make clean && make install

--- a/Readme.md
+++ b/Readme.md
@@ -59,16 +59,22 @@ You can build pg_cjk_parser in a docker container.
 
 1. Clone this repository into your local computer, say in /home/user/pg_cjk_parser
 2. Ener /home/user/pg_cjk_parser
-3. Build the docker image postgres:11-dev
+3. Build the docker image postgres:12-dev
 
+To build this extension for PostgreSQL 12
 ```bash
-docker build -t postgres:11-dev . 
+docker build -t postgres:12-dev . -f Dockerfile_pg12
+```
+
+To build this extension for PostgreSQL 16
+```bash
+docker build -t postgres:12-dev . -f Dockerfile_pg16
 ```
 
 4. Run the following command
 
 ```bash
-docker run -it --rm -v $(PWD):/root/code postgres:11-dev /bin/bash -c "cd /root/code && make clean && make"
+docker run -it --rm -v $(pwd):/root/code postgres:12-dev /bin/bash -c "cd /root/code && make clean && make"
 ```
 
 Then pg_cjk_parser.bc and pg_cjk_parser.so will be available in current directory (/home/user/pg_cjk_parser). You can manually install the parser to a PostgreSQL instances or you can install it as an extension.
@@ -79,11 +85,12 @@ You can manually install pg_cjk_parser or you can install it as an extension.
 
 ### Install as an extension
 
-Let's say that you have an instance of PostgreSQL 11 running, either on a docker container on a server.
+Let's say that you have an instance of PostgreSQL 12 running, either on a docker container on a server.
 Make sure you have the following dependencies installed.
 
 ```bash
-sudo apt-get install -y postgresql-server-dev-all
+# replace 12 with 16 if you build this extension for pg 16
+sudo apt-get install -y postgresql-server-dev-12 
 sudo apt-get install -y gcc
 sudo apt-get install -y icu-devtools libicu-dev
 ```
@@ -103,6 +110,7 @@ Run the following command on the server
 ```bash
 cd /home/user/parser
 make clean && make install
+sudo make USE_PGXS=1 install
 ```
 
 Connect to your server via pgAdmin or other clients and then execute the following sql to create the pg_cjk_parser extension.
@@ -132,10 +140,15 @@ Now you can execute the sql demonstrated in the introduction section to see the 
 
 ### Docker image
 
-There is a Dockerfile in this repository which helps you build a docker image based on postgres:11.
+There is a Dockerfile in this repository which helps you build a docker image based on postgres:12.
 
 ```bash
-docker build -t postgres:11-dev .
+docker build -t postgres:12-dev . -f Dockerfile_pg12
+```
+
+There is also a Dockerfile in this repository which helps you build a docker image based on postgres:16.
+```bash
+docker build -t postgres:16-dev . -f Dockerfile_pg16
 ```
 
 If you use this image to start an instance of postgres:11, all you need to do is to create the extension, search parser and configuration in pgAdmin.
@@ -334,6 +347,14 @@ to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多�
 |to_tsvector|to_tsquery|to_tsquery|?boolean?|?boolean?|
 |-|-|-|-|-|
 |'doraemnon':1 'nobita':2 'χψψωω':22 '「':3 '」':15 'えも':6 'のび':8 'の牧':11 'び太':9 'もん':7 'ドラ':4 'ラえ':5 '場物':13 '多拉':16 '大雄':21 '太の':10 '梦':18 '比大':20 '牧場':12 '物語':14 '野比':19|"'のび' & 'び太'"|"'野比' & '比大' & '大雄'"|true|true|
+
+```sql
+SELECT to_tsvector('大韩民国개인정보의 수집 및 이용 목적(「개인정보 보호법」 제15조)'), to_tsquery('「大韩民国개인정보');
+```
+
+|to_tsvector|to_tsquery|
+|-|-|
+| '15':21 '「':13 '」':19 '国개':4 '大韩':1 '民国':3 '韩民':2 '개인':5,14 '목적':12 '및':10 '보의':8 '보호':17 '수집':9 '이용':11 '인정':6,15 '정보':7,16 '제':20 '조':22 '호법':18|'「' & '大韩' & '韩民' & '民国' & '国개' & '개인' & '인정' & '정보'|
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 # Postgres CJK Parser - pg_cjk_parser
 
-Postgres CJK Parser pg_cjk_parser is a fts (full text search) parser derived from the default parser in PostgreSQL 11. When a postgres database uses utf-8 encoding, this parser supports all the features of the default parser while splitting CJK (Chinese, Japanese, Korean) characters into 2-gram tokens. If the database's encoding is not utf-8, the parser behaves just like the default parser.
+Postgres CJK Parser pg_cjk_parser is a fts (full text search) parser derived from the default parser in PostgreSQL. When a postgres database uses utf-8 encoding, this parser supports all the features of the default parser while splitting CJK (Chinese, Japanese, Korean) characters into 2-gram tokens. If the database's encoding is not utf-8, the parser behaves just like the default parser.
+
+Now pg_cjk_parser supports PostgreSQL 11 to 16.
 
 ## Introduction
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 Postgres CJK Parser pg_cjk_parser is a fts (full text search) parser derived from the default parser in PostgreSQL. When a postgres database uses utf-8 encoding, this parser supports all the features of the default parser while splitting CJK (Chinese, Japanese, Korean) characters into 2-gram tokens. If the database's encoding is not utf-8, the parser behaves just like the default parser.
 
-Now pg_cjk_parser supports PostgreSQL 11 to 16.
+Now pg_cjk_parser supports PostgreSQL 12 to 16.
 
 ## Introduction
 
@@ -153,7 +153,7 @@ There is also a Dockerfile in this repository which helps you build a docker ima
 docker build -t postgres:16-dev . -f Dockerfile_pg16
 ```
 
-If you use this image to start an instance of postgres:11, all you need to do is to create the extension, search parser and configuration in pgAdmin.
+If you use this image to start an instance of postgres:12, all you need to do is to create the extension, search parser and configuration in pgAdmin.
 
 Connect to your server via pgAdmin or other clients and then execute the following sql to create the pg_cjk_parser extension.
 
@@ -182,10 +182,10 @@ Now you can execute the sql demonstrated in the introduction section to see the 
 
 ### Install manually
 
-Suppose you have an docker instance of postgres name postgres_db_1 whose image is postgres:11.
+Suppose you have an docker instance of postgres name postgres_db_1 whose image is postgres:12.
 
 ```bash
-docker cp pg_cjk_parser.so postgres_db_1:/usr/lib/postgresql/11/lib/
+docker cp pg_cjk_parser.so postgres_db_1:/usr/lib/postgresql/12/lib/
 ```
 
 Connect to the postgres instance via pgAdmin or other clients and then execute the following sql

--- a/postgres-12.sh
+++ b/postgres-12.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+	
+docker run --name postgres12 -e POSTGRES_PASSWORD=password -d postgres:12-dev
+sleep 5
+docker exec postgres12 psql -U postgres -c 'CREATE EXTENSION pg_cjk_parser;'
+docker exec postgres12 psql -U postgres -c "CREATE TEXT SEARCH PARSER public.pg_cjk_parser (START = prsd2_cjk_start, GETTOKEN = prsd2_cjk_nexttoken, END = prsd2_cjk_end, LEXTYPES = prsd2_cjk_lextype, HEADLINE = prsd2_cjk_headline); CREATE TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ( PARSER = pg_cjk_parser ); SET default_text_search_config = 'public.config_2_gram_cjk';"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR asciihword WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR cjk WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR email WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR asciiword WITH english_stem;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR entity WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR file WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR float WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR host WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword_asciipart WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword_numpart WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword_part WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR int WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR numhword WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR numword WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR protocol WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR sfloat WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR tag WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR uint WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR url WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR url_path WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR version WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR word WITH simple;"
+
+docker exec postgres12 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多拉A梦 野比大雄χΨψΩω'), to_tsquery('のび太'), to_tsquery('野比大雄');"
+
+docker exec postgres12 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('大韩民国개인정보의 수집 및 이용 목적(「개인정보 보호법」 제15조)'), to_tsquery('「大韩民国개인정보');"
+
+docker stop postgres12 && docker rm postgres12

--- a/postgres-16.sh
+++ b/postgres-16.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+	
+docker run --name postgres16 -e POSTGRES_PASSWORD=password -d postgres:16-dev
+sleep 5
+docker exec postgres16  psql -U postgres -c 'CREATE EXTENSION pg_cjk_parser;'
+docker exec postgres16 psql -U postgres -c "CREATE TEXT SEARCH PARSER public.pg_cjk_parser (START = prsd2_cjk_start, GETTOKEN = prsd2_cjk_nexttoken, END = prsd2_cjk_end, LEXTYPES = prsd2_cjk_lextype, HEADLINE = prsd2_cjk_headline); CREATE TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ( PARSER = pg_cjk_parser ); SET default_text_search_config = 'public.config_2_gram_cjk';"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR asciihword WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR cjk WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR email WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR asciiword WITH english_stem;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR entity WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR file WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR float WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR host WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword_asciipart WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword_numpart WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR hword_part WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR int WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR numhword WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR numword WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR protocol WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR sfloat WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR tag WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR uint WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR url WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR url_path WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR version WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR word WITH simple;"
+
+docker exec postgres16 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多拉A梦 野比大雄χΨψΩω'), to_tsquery('のび太'), to_tsquery('野比大雄');"
+
+docker exec postgres16 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('大韩民国개인정보의 수집 및 이용 목적(「개인정보 보호법」 제15조)'), to_tsquery('「大韩民国개인정보');"
+
+docker stop postgres16 && docker rm postgres16


### PR DESCRIPTION
Close #4
Close #3

1.  `pg_atoi` has been removed so we need to replace it with `pg_strtoint32` to support PostgreSQL >= v13 
2.  Add extra code point detection to support Korean Hangul