### PR TITLE
Update Readme.md - Add zht2zhs.h to list of required installation files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,6 +108,7 @@ Copy the following files
 > pg_cjk_parser.c
 > pg_cjk_parser.control
 > pg_cjk_parser--0.0.1.sql
+> zht2zhs.h
 > Makefile
 
 to a directory on the server, say, /home/user/parser/


### PR DESCRIPTION
I've noticed `zht2zhs.h` haven't been mentioned in the installation tutorial.