### PR TITLE
port: fix lc_ctype_is_c removal in PG18; add PG18 CI job

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ if ! echo "$STAGED" | grep -qE '\.(c|h|sql|control)$|^Makefile$|^postgres-'; the
     exit 0
 fi
 
-echo "pre-commit: building images and running tests for PG11, PG12, PG16..."
+echo "pre-commit: building images and running tests for PG11, PG12, PG16, PG18..."
 
 build() {
     local label=$1; shift
@@ -38,5 +38,8 @@ run_tests "PostgreSQL 12" postgres-12.sh
 
 build "PG16" --build-arg POSTGRES_VERSION=16 -f Dockerfile_alpine -t postgres:16-dev .
 run_tests "PostgreSQL 16" postgres-16.sh
+
+build "PG18" --build-arg POSTGRES_VERSION=18 -f Dockerfile_alpine -t postgres:dev .
+run_tests "PostgreSQL 18" postgres-1x.sh
 
 echo "pre-commit: all tests passed"

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -209,3 +209,32 @@ jobs:
       -
         name: Run bash script to verify image postgres:dev
         run: docker pull localhost:5000/postgres:dev && docker tag localhost:5000/postgres:dev postgres:dev && chmod +x ./postgres-1x.sh && ./postgres-1x.sh
+
+  PostgreSQL-18:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v6
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
+      -
+        name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          build-args: POSTGRES_VERSION=18
+          file: Dockerfile_alpine
+          tags: localhost:5000/postgres:dev
+      -
+        name: Run bash script to verify image postgres:dev
+        run: docker pull localhost:5000/postgres:dev && docker tag localhost:5000/postgres:dev postgres:dev && chmod +x ./postgres-1x.sh && ./postgres-1x.sh

--- a/pg_cjk_parser.c
+++ b/pg_cjk_parser.c
@@ -16,7 +16,9 @@
 
 #include <limits.h>
 
+#if PG_VERSION_NUM < 150000
 #include "catalog/pg_collation.h"
+#endif
 #include "commands/defrem.h"
 #include "tsearch/ts_locale.h"
 #include "tsearch/ts_public.h"
@@ -316,11 +318,14 @@ TParserInit(char *str, int len)
 	 */
 	if (prs->charmaxlen > 1)
 	{
-		Oid			collation = DEFAULT_COLLATION_OID;	/* TODO */
 		pg_locale_t mylocale = 0;	/* TODO */
 
 		prs->usewide = true;
-		if (lc_ctype_is_c(collation))
+#if PG_VERSION_NUM >= 150000
+		if (database_ctype_is_c)
+#else
+		if (lc_ctype_is_c(DEFAULT_COLLATION_OID))
+#endif
 		{
 			/*
 			 * char2wchar doesn't work for C-locale and sizeof(pg_wchar) could


### PR DESCRIPTION
What:
- lc_ctype_is_c(Oid) was removed in PostgreSQL 18. Guard the call with #if PG_VERSION_NUM >= 150000 to use the equivalent database_ctype_is_c boolean (available since PG15), falling back to lc_ctype_is_c for PG11-14. Also guard the now-unused catalog/pg_collation.h include.
- Add PostgreSQL-18 job to the CI workflow using Dockerfile_alpine. PG18 reuses postgres-1x.sh (same output format as PG13+, no blocker).
- Extend the pre-commit hook to build and test PG18 via postgres-1x.sh.

Why:
The extension failed to compile on PG18 because lc_ctype_is_c was removed upstream. PG18 is the current stable release (18.3 as of February 2026) so this is a hard build blocker for new deployments. Reusing postgres-1x.sh avoids a redundant test script since PG18 produces identical tsvector and tsquery output to PG13+. Tested locally: PG16 and PG18 both build and all tests pass.