### PR TITLE
docs: close Bug 001 and Bug 002 — both fixed in PR #13

### DIFF
--- a/issues/2026-04-30-bug-001-utf8_cjkCodePoint-missing-return.md
+++ b/issues/2026-04-30-bug-001-utf8_cjkCodePoint-missing-return.md
@@ -1,7 +1,9 @@
 # Bug 001 — `utf8_cjkCodePoint`: missing `return` for 4-byte UTF-8 sequences
 
+**Status: FIXED** — merged in commit `b62aa51` (PR #13), 2026-04-30
+
 **File:** `pg_cjk_parser.c`  
-**Function:** `utf8_cjkCodePoint` (~line 705)  
+**Function:** `utf8_cjkCodePoint`  
 **Severity:** Medium (code logic is wrong; current practical impact is masked by Bug 002)
 
 ---
@@ -80,4 +82,4 @@ if(((c ^ 0xF0) & 0xF8) == 0){
 SELECT prsd2_zht2zhs('𠀀漢𠁐漢');
 ```
 
-Added to CI scripts as a failing test (will pass once both bugs are fixed).
+Regression test added to all CI scripts (`postgres-11/12/16/1x.sh`). Confirmed failing before fix and passing after.

--- a/issues/2026-04-30-bug-002-prsd2_zht2zhs-wrong-pointer.md
+++ b/issues/2026-04-30-bug-002-prsd2_zht2zhs-wrong-pointer.md
@@ -1,7 +1,9 @@
 # Bug 002 — `prsd2_zht2zhs`: wrong pointer in `else` branch skips conversions
 
+**Status: FIXED** — merged in commit `b62aa51` (PR #13), 2026-04-30
+
 **File:** `pg_cjk_parser.c`  
-**Function:** `prsd2_zht2zhs` (~line 2982)  
+**Function:** `prsd2_zht2zhs`  
 **Severity:** High — causes `prsd2_zht2zhs` to silently miss Traditional→Simplified conversions
 
 ---
@@ -103,7 +105,7 @@ and would otherwise stall `pos` forever).
 ## Tests that reveal this bug
 
 Added to all CI test scripts (`postgres-11.sh`, `postgres-12.sh`, `postgres-16.sh`,
-`postgres-1x.sh`).  Both tests fail with the current code and pass after the fix.
+`postgres-1x.sh`). Both tests confirmed failing before fix and passing after.
 
 ```sql
 -- Bug 002 alone: 2-byte Latin char before ASCII before Traditional Chinese


### PR DESCRIPTION
Both bugs in cjk_zht2zhs are resolved and regression tests pass on PG11 through PG18. Mark issue docs with fix commit and confirmed status.