### PR TITLE
improve: version bump to 0.1.0; lint in pre-commit; CI and code fixes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,17 @@ if ! echo "$STAGED" | grep -qE '\.(c|h|sql|control)$|^Makefile$|^postgres-'; the
     exit 0
 fi
 
-echo "pre-commit: building images and running tests for PG11, PG12, PG16, PG18..."
+echo "pre-commit: linting and building images and running tests for PG11, PG12, PG16, PG18..."
+
+# --- Lint: fail on any compiler warning or error ---
+echo "--- lint: C warnings (PG16) ---"
+BUILD_LOG=$(docker build --build-arg POSTGRES_VERSION=16 -f Dockerfile_alpine -t postgres:16-dev . 2>&1)
+WARNINGS=$(echo "$BUILD_LOG" | grep -E 'pg_cjk_parser\.(c|h):[0-9]+:[0-9]+: (warning|error):' || true)
+if [ -n "$WARNINGS" ]; then
+    echo "$WARNINGS"
+    echo "ERROR: compiler warnings/errors — fix before committing"
+    exit 1
+fi
 
 build() {
     local label=$1; shift

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,18 +4,26 @@ set -e
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-# Skip if no source, SQL, or test-script files are staged
+# Skip if no source, SQL, control, Dockerfile, Makefile, or test-script files are staged
 STAGED=$(git diff --cached --name-only)
-if ! echo "$STAGED" | grep -qE '\.(c|h|sql|control)$|^Makefile$|^postgres-'; then
+if ! echo "$STAGED" | grep -qE '\.(c|h|sql|control)$|^Makefile$|^Dockerfile|^postgres-'; then
     echo "pre-commit: no source or test changes — skipping build tests"
     exit 0
+fi
+
+# Force a clean build when Dockerfile or Makefile changes to prevent Docker
+# layer cache from hiding packaging errors (e.g. missing COPY instructions).
+NOCACHE=""
+if echo "$STAGED" | grep -qE '^Dockerfile|^Makefile$'; then
+    NOCACHE="--no-cache"
+    echo "pre-commit: Dockerfile/Makefile changed — building without cache"
 fi
 
 echo "pre-commit: linting and building images and running tests for PG11, PG12, PG16, PG18..."
 
 # --- Lint: fail on any compiler warning or error ---
 echo "--- lint: C warnings (PG16) ---"
-BUILD_LOG=$(docker build --build-arg POSTGRES_VERSION=16 -f Dockerfile_alpine -t postgres:16-dev . 2>&1)
+BUILD_LOG=$(docker build $NOCACHE --build-arg POSTGRES_VERSION=16 -f Dockerfile_alpine -t postgres:16-dev . 2>&1)
 WARNINGS=$(echo "$BUILD_LOG" | grep -E 'pg_cjk_parser\.(c|h):[0-9]+:[0-9]+: (warning|error):' || true)
 if [ -n "$WARNINGS" ]; then
     echo "$WARNINGS"
@@ -25,7 +33,7 @@ fi
 
 build() {
     local label=$1; shift
-    if ! docker build "$@" > /dev/null 2>&1; then
+    if ! docker build $NOCACHE "$@" > /dev/null 2>&1; then
         echo "ERROR: $label image build failed"
         exit 1
     fi

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -92,8 +92,8 @@ jobs:
           tags: localhost:5000/postgres:dev
       -
         name: Run bash script to verify image postgres:dev
-        run: docker pull localhost:5000/postgres:dev && docker tag localhost:5000/postgres:dev postgres:12-dev && chmod +x ./postgres-12.sh && ./postgres-12.sh
-        
+        run: docker pull localhost:5000/postgres:dev && docker tag localhost:5000/postgres:dev postgres:dev && chmod +x ./postgres-1x.sh && ./postgres-1x.sh
+
   PostgreSQL-14:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/postgress12_16.yml
+++ b/.github/workflows/postgress12_16.yml
@@ -92,7 +92,7 @@ jobs:
           tags: localhost:5000/postgres:dev
       -
         name: Run bash script to verify image postgres:dev
-        run: docker pull localhost:5000/postgres:dev && docker tag localhost:5000/postgres:dev postgres:dev && chmod +x ./postgres-1x.sh && ./postgres-1x.sh
+        run: docker pull localhost:5000/postgres:dev && docker tag localhost:5000/postgres:dev postgres:12-dev && chmod +x ./postgres-12.sh && ./postgres-12.sh
 
   PostgreSQL-14:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,4 @@
 - Add tests that actually run and reveal the bug — do not just infer correctness from reading code.
 - Run the tests against the buggy code first to confirm they fail, then fix the bug and confirm they pass.
 - Correctness before anything else (style, refactoring, etc.).
+- The pre-commit hook also runs a compiler-warning lint pass (PG16 build). Zero warnings required.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG POSTGRES_VERSION=16
-FROM postgres:$POSTGRES_VERSION as build
+FROM postgres:$POSTGRES_VERSION AS build
 ARG POSTGRES_VERSION=16
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql-server-dev-$POSTGRES_VERSION gcc make icu-devtools libicu-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY pg_cjk_parser.c /root/parser/
 COPY pg_cjk_parser.control /root/parser/
 COPY Makefile /root/parser/
 COPY pg_cjk_parser--0.0.1.sql /root/parser/
+COPY pg_cjk_parser--0.0.1--0.1.0.sql /root/parser/
+COPY pg_cjk_parser--0.1.0.sql /root/parser/
 COPY zht2zhs.h /root/parser/
 RUN make clean && make install
 
@@ -17,4 +19,6 @@ ARG POSTGRES_VERSION=16
 COPY --from=build /root/parser/pg_cjk_parser.bc /usr/lib/postgresql/$POSTGRES_VERSION/lib/bitcode
 COPY --from=build /root/parser/pg_cjk_parser.so /usr/lib/postgresql/$POSTGRES_VERSION/lib
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.0.1--0.1.0.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.1.0.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
 COPY --from=build /root/parser/pg_cjk_parser.control /usr/share/postgresql/$POSTGRES_VERSION/extension

--- a/Dockerfile_alpine
+++ b/Dockerfile_alpine
@@ -12,6 +12,8 @@ COPY pg_cjk_parser.c /root/parser/
 COPY pg_cjk_parser.control /root/parser/
 COPY Makefile /root/parser/
 COPY pg_cjk_parser--0.0.1.sql /root/parser/
+COPY pg_cjk_parser--0.0.1--0.1.0.sql /root/parser/
+COPY pg_cjk_parser--0.1.0.sql /root/parser/
 COPY zht2zhs.h /root/parser/
 RUN make clean && make install
 
@@ -19,4 +21,6 @@ FROM postgres:$POSTGRES_VERSION-alpine
 COPY --from=build /root/parser/pg_cjk_parser.bc /usr/local/lib/postgresql/bitcode
 COPY --from=build /root/parser/pg_cjk_parser.so /usr/local/lib/postgresql/
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1.sql /usr/local/share/postgresql/extension/
+COPY --from=build /root/parser/pg_cjk_parser--0.0.1--0.1.0.sql /usr/local/share/postgresql/extension/
+COPY --from=build /root/parser/pg_cjk_parser--0.1.0.sql /usr/local/share/postgresql/extension/
 COPY --from=build /root/parser/pg_cjk_parser.control /usr/local/share/postgresql/extension/

--- a/Dockerfile_alpine
+++ b/Dockerfile_alpine
@@ -1,6 +1,6 @@
 
 ARG POSTGRES_VERSION=16
-FROM postgres:$POSTGRES_VERSION-alpine as build
+FROM postgres:$POSTGRES_VERSION-alpine AS build
 ARG POSTGRES_VERSION=16
 RUN apk update && apk add musl-dev icu-dev make && \
     LLVM_VER=$(pg_config --configure | grep -oE "llvm[0-9]+" | head -1 | grep -oE "[0-9]+") && \

--- a/Dockerfile_pg11
+++ b/Dockerfile_pg11
@@ -1,5 +1,5 @@
 
-FROM postgres:11-alpine3.13 as build
+FROM postgres:11-alpine3.13 AS build
 RUN apk update && apk add build-base postgresql postgresql-dev gcc make clang
 
 RUN mkdir -p /root/parser

--- a/Dockerfile_pg11
+++ b/Dockerfile_pg11
@@ -8,6 +8,8 @@ COPY pg_cjk_parser.c /root/parser/
 COPY pg_cjk_parser.control /root/parser/
 COPY Makefile /root/parser/
 COPY pg_cjk_parser--0.0.1.sql /root/parser/
+COPY pg_cjk_parser--0.0.1--0.1.0.sql /root/parser/
+COPY pg_cjk_parser--0.1.0.sql /root/parser/
 COPY zht2zhs.h /root/parser/
 RUN make clean && make install
 
@@ -15,4 +17,6 @@ FROM postgres:11-alpine3.13
 COPY --from=build /root/parser/pg_cjk_parser.bc /usr/local/lib/postgresql/bitcode
 COPY --from=build /root/parser/pg_cjk_parser.so /usr/local/lib/postgresql
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1.sql /usr/local/share/postgresql/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.0.1--0.1.0.sql /usr/local/share/postgresql/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.1.0.sql /usr/local/share/postgresql/extension
 COPY --from=build /root/parser/pg_cjk_parser.control /usr/local/share/postgresql/extension

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MODULES = pg_cjk_parser
 EXTENSION = pg_cjk_parser
-DATA = pg_cjk_parser--0.0.1.sql
+DATA = pg_cjk_parser--0.0.1.sql pg_cjk_parser--0.0.1--0.1.0.sql pg_cjk_parser--0.1.0.sql
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,15 @@
 
 Postgres CJK Parser pg_cjk_parser is a fts (full text search) parser derived from the default parser in PostgreSQL. When a postgres database uses utf-8 encoding, this parser supports all the features of the default parser while splitting CJK (Chinese, Japanese, Korean) characters into 2-gram tokens. If the database's encoding is not utf-8, the parser behaves just like the default parser.
 
-Now pg_cjk_parser supports PostgreSQL 11 to 17.
+pg_cjk_parser supports PostgreSQL 11 through 18.
+
+## cjk_zht2zhs
+
+`cjk_zht2zhs(text) → text` converts Traditional Chinese characters to Simplified Chinese in-place. All other characters (ASCII, Latin, Japanese, Korean, etc.) are passed through unchanged.
+
+```sql
+SELECT cjk_zht2zhs('漢語');  -- returns '汉语'
+```
 
 ## Introduction
 

--- a/pg_cjk_parser--0.0.1--0.1.0.sql
+++ b/pg_cjk_parser--0.0.1--0.1.0.sql
@@ -1,0 +1,10 @@
+-- pg_cjk_parser upgrade script: 0.0.1 -> 0.1.0
+--
+-- No SQL-level objects changed in this release.
+-- Fixes are in the C extension:
+--   - cjk_zht2zhs: wrong pointer (*cur vs *(cur+pos)) caused silent
+--     conversion misses for mixed-encoding strings (Bug 002)
+--   - utf8_cjkCodePoint: missing return for 4-byte sequences (Bug 001)
+--   - lc_ctype_is_c removed in PG18; use database_ctype_is_c on PG15+
+--   - pg_mblen replaced with pg_mblen_range for buffer safety on PG14+
+--   - hlCover: new O(n) algorithm using TS_execute_locations on PG16+

--- a/pg_cjk_parser--0.1.0.sql
+++ b/pg_cjk_parser--0.1.0.sql
@@ -1,0 +1,47 @@
+--
+--
+\echo Use "CREATE EXTENSION pg_cjk_parser" to load this file. \quit
+
+CREATE FUNCTION public.prsd2_cjk_start(IN internal, IN integer)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_start'
+;
+
+
+CREATE FUNCTION public.prsd2_cjk_nexttoken(IN internal, IN internal, IN internal)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_nexttoken'
+;
+
+	
+CREATE FUNCTION public.prsd2_cjk_end(IN internal)
+    RETURNS void
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_end'
+;
+
+CREATE FUNCTION public.prsd2_cjk_lextype(IN internal)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_lextype'
+;
+
+CREATE FUNCTION public.prsd2_cjk_headline(IN internal, IN internal, IN tsquery)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_headline'
+;
+
+CREATE FUNCTION public.cjk_zht2zhs(IN text)
+    RETURNS text
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_zht2zhs'
+;

--- a/pg_cjk_parser.c
+++ b/pg_cjk_parser.c
@@ -330,7 +330,7 @@ TParserInit(char *str, int len)
 	 */
 	if (prs->charmaxlen > 1)
 	{
-		pg_locale_t mylocale = 0;	/* TODO */
+		pg_locale_t mylocale = 0;	/* NULL = use database default locale */
 
 		prs->usewide = true;
 #if PG_VERSION_NUM >= 150000
@@ -769,6 +769,9 @@ utf8_setCjkCodePoint(char *s, unsigned int codePoint)
 			return;
 		}
 	}
+
+	elog(ERROR, "pg_cjk_parser: codepoint 0x%x is not in any known CJK range",
+		 codePoint);
 }
 
 static int

--- a/pg_cjk_parser.control
+++ b/pg_cjk_parser.control
@@ -1,4 +1,4 @@
 comment = 'A token parser derived from pg default parser that parses CJK into 2-gram'
-default_version = '0.0.1'
+default_version = '0.1.0'
 module_pathname = '$libdir/pg_cjk_parser'
 relocatable = true

--- a/postgres-11.sh
+++ b/postgres-11.sh
@@ -125,4 +125,26 @@ then
     exit 1
 fi
 
+
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres11 && docker rm postgres11
+    exit 1
+fi
+
+# Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+echo $OUTPUT
+if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
+then
+    echo "ALTER EXTENSION pg_cjk_parser UPDATE failed — upgrade SQL script missing from image"
+    docker stop postgres11 && docker rm postgres11
+    exit 1
+fi
+
 docker stop postgres11 && docker rm postgres11

--- a/postgres-11.sh
+++ b/postgres-11.sh
@@ -100,6 +100,17 @@ then
     exit 1
 fi
 
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres11 && docker rm postgres11
+    exit 1
+fi
+
 # Bug 001 + 002: 4-byte CJK Ext-B characters interspersed with Traditional Chinese.
 # Bug 001 (missing return in utf8_cjkCodePoint) causes 𠁐 to return 0 and fall to else.
 # Bug 002 then reads *cur (0xE6, 3-byte lead of 汉) instead of *(cur+pos) (0xF0, 4-byte

--- a/postgres-12.sh
+++ b/postgres-12.sh
@@ -100,6 +100,17 @@ then
     exit 1
 fi
 
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres12 && docker rm postgres12
+    exit 1
+fi
+
 # Bug 001 + 002: 4-byte CJK Ext-B characters interspersed with Traditional Chinese.
 # Bug 001 (missing return in utf8_cjkCodePoint) causes 𠁐 to return 0 and fall to else.
 # Bug 002 then reads *cur (0xE6, 3-byte lead of 汉) instead of *(cur+pos) (0xF0, 4-byte

--- a/postgres-12.sh
+++ b/postgres-12.sh
@@ -125,4 +125,26 @@ then
     exit 1
 fi
 
+
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres12 && docker rm postgres12
+    exit 1
+fi
+
+# Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+echo $OUTPUT
+if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
+then
+    echo "ALTER EXTENSION pg_cjk_parser UPDATE failed — upgrade SQL script missing from image"
+    docker stop postgres12 && docker rm postgres12
+    exit 1
+fi
+
 docker stop postgres12 && docker rm postgres12

--- a/postgres-16.sh
+++ b/postgres-16.sh
@@ -100,6 +100,17 @@ then
     exit 1
 fi
 
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres16 && docker rm postgres16
+    exit 1
+fi
+
 # Bug 001 + 002: 4-byte CJK Ext-B characters interspersed with Traditional Chinese.
 # Bug 001 (missing return in utf8_cjkCodePoint) causes 𠁐 to return 0 and fall to else.
 # Bug 002 then reads *cur (0xE6, 3-byte lead of 汉) instead of *(cur+pos) (0xF0, 4-byte

--- a/postgres-16.sh
+++ b/postgres-16.sh
@@ -125,4 +125,26 @@ then
     exit 1
 fi
 
+
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres16 && docker rm postgres16
+    exit 1
+fi
+
+# Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+echo $OUTPUT
+if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
+then
+    echo "ALTER EXTENSION pg_cjk_parser UPDATE failed — upgrade SQL script missing from image"
+    docker stop postgres16 && docker rm postgres16
+    exit 1
+fi
+
 docker stop postgres16 && docker rm postgres16

--- a/postgres-1x.sh
+++ b/postgres-1x.sh
@@ -100,6 +100,17 @@ then
     exit 1
 fi
 
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres_db && docker rm postgres_db
+    exit 1
+fi
+
 # Bug 001 + 002: 4-byte CJK Ext-B characters interspersed with Traditional Chinese.
 # Bug 001 (missing return in utf8_cjkCodePoint) causes 𠁐 to return 0 and fall to else.
 # Bug 002 then reads *cur (0xE6, 3-byte lead of 汉) instead of *(cur+pos) (0xF0, 4-byte

--- a/postgres-1x.sh
+++ b/postgres-1x.sh
@@ -125,4 +125,26 @@ then
     exit 1
 fi
 
+
+# Test utf8_setCjkCodePoint is not a silent no-op:
+# if it silently did nothing, Traditional Chinese input would be returned unchanged
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('漢') != '漢';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: utf8_setCjkCodePoint appears to be a silent no-op"
+    docker stop postgres_db && docker rm postgres_db
+    exit 1
+fi
+
+# Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+echo $OUTPUT
+if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
+then
+    echo "ALTER EXTENSION pg_cjk_parser UPDATE failed — upgrade SQL script missing from image"
+    docker stop postgres_db && docker rm postgres_db
+    exit 1
+fi
+
 docker stop postgres_db && docker rm postgres_db


### PR DESCRIPTION
What:
- Bump version from 0.0.1 to 0.1.0. Add pg_cjk_parser--0.1.0.sql (fresh install at new version) and pg_cjk_parser--0.0.1--0.1.0.sql (upgrade path for existing installs via ALTER EXTENSION pg_cjk_parser UPDATE). Makefile updated to install all three SQL files.

- Add compiler-warning lint step to pre-commit hook. Builds PG16 and fails the commit if any warning or error appears in the C source. Zero-warning policy enforced before every commit touching .c/.h files.

- Fix CI PG13 job: was tagging image as postgres:12-dev and running postgres-12.sh (wrong script). Now tags as postgres:dev and runs postgres-1x.sh, consistent with PG14-18.

- Fix Dockerfile AS casing: all three Dockerfiles used lowercase 'as' in FROM ... AS build, triggering a Docker lint warning on every build. Changed to uppercase AS.

- utf8_setCjkCodePoint silent no-op: the function returned without writing anything if codePoint did not match any known CJK range. Added elog(ERROR) so the condition cannot go unnoticed. Added a test to all CI scripts: SELECT cjk_zht2zhs('漢') != '漢' must return true; a silent no-op would cause it to return false.

- mylocale TODO comment clarified: NULL is intentional (use the database default locale), not a missing implementation.

- README updated: mentions PG18 support and documents cjk_zht2zhs.

Why:
Users on 0.0.1 who received the bug-fix C extension (PR #13) had no upgrade path via ALTER EXTENSION. The version bump formalises the fix as a release. The lint step catches regressions before they reach CI. The PG13 CI job has been running the wrong test suite since it was added.