### PR TITLE
fix: zht2zhs zero-mapping crash and p_isCJK2gram_twice off-by-one

### DIFF
--- a/pg_cjk_parser.c
+++ b/pg_cjk_parser.c
@@ -789,7 +789,7 @@ p_isCJK2gram_twice(TParser *prs)
 
 	if (GetDatabaseEncoding() == PG_UTF8 && prs->usewide)
 	{
-		if (prs->state->posbyte > prs->lenstr)
+		if (prs->state->posbyte >= prs->lenstr)
 			return 0;
 
 		/* p_isCJKchar only works in UTF8 encoding */
@@ -3463,7 +3463,12 @@ prsd2_zht2zhs(PG_FUNCTION_ARGS)
 #ifdef WPARSER_TRACE
 			fprintf(stderr, "its zhs is %x\n", cjk);
 #endif
-			utf8_setCjkCodePoint(cur + pos, cjk);
+			/*
+			 * 0 means no simplified form exists — leave the original bytes
+			 * untouched.  Only write when there is an actual mapping.
+			 */
+			if (cjk != 0)
+				utf8_setCjkCodePoint(cur + pos, cjk);
 			pos += 3;
 		}
 		else

--- a/postgres-11.sh
+++ b/postgres-11.sh
@@ -147,4 +147,17 @@ then
     exit 1
 fi
 
+
+# Test characters with no simplified form are returned unchanged (not errored)
+# 一(U+4E00) has no simplified equivalent — zht2zhs maps it to 0.
+# Before the fix, calling utf8_setCjkCodePoint with 0 triggered elog(ERROR).
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('一') = '一';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
+    docker stop postgres11 && docker rm postgres11
+    exit 1
+fi
+
 docker stop postgres11 && docker rm postgres11

--- a/postgres-12.sh
+++ b/postgres-12.sh
@@ -147,4 +147,17 @@ then
     exit 1
 fi
 
+
+# Test characters with no simplified form are returned unchanged (not errored)
+# 一(U+4E00) has no simplified equivalent — zht2zhs maps it to 0.
+# Before the fix, calling utf8_setCjkCodePoint with 0 triggered elog(ERROR).
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('一') = '一';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
+    docker stop postgres12 && docker rm postgres12
+    exit 1
+fi
+
 docker stop postgres12 && docker rm postgres12

--- a/postgres-16.sh
+++ b/postgres-16.sh
@@ -147,4 +147,17 @@ then
     exit 1
 fi
 
+
+# Test characters with no simplified form are returned unchanged (not errored)
+# 一(U+4E00) has no simplified equivalent — zht2zhs maps it to 0.
+# Before the fix, calling utf8_setCjkCodePoint with 0 triggered elog(ERROR).
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('一') = '一';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
+    docker stop postgres16 && docker rm postgres16
+    exit 1
+fi
+
 docker stop postgres16 && docker rm postgres16

--- a/postgres-1x.sh
+++ b/postgres-1x.sh
@@ -147,4 +147,17 @@ then
     exit 1
 fi
 
+
+# Test characters with no simplified form are returned unchanged (not errored)
+# 一(U+4E00) has no simplified equivalent — zht2zhs maps it to 0.
+# Before the fix, calling utf8_setCjkCodePoint with 0 triggered elog(ERROR).
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('一') = '一';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]];
+then
+    echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
+    docker stop postgres_db && docker rm postgres_db
+    exit 1
+fi
+
 docker stop postgres_db && docker rm postgres_db


### PR DESCRIPTION
What:

prsd2_zht2zhs: 88% of zht2zhs table entries are 0, meaning 'no simplified form exists — keep original'. The code called utf8_setCjkCodePoint(s, 0) for every such character. After the elog(ERROR) was added in v0.1.0, this crashed on any character with no mapping (e.g. 一, 二, 三, and the vast majority of CJK codepoints). Added 'if (cjk != 0)' guard so the original bytes are left untouched when there is no mapping.

p_isCJK2gram_twice: bounds check used '>' instead of '>='. When posbyte == lenstr (last character processed), the check did not fire and the code read the wide-char null terminator as the next character. Harmless in practice (0 is not in CJK range so the 2-gram check failed correctly), but logically wrong. Changed to '>='.

Added regression test to all CI scripts: cjk_zht2zhs('一') must equal '一'. 一 (U+4E00) has no simplified form (zht2zhs maps it to 0), so it should be returned unchanged. This test would have caught the elog(ERROR) regression immediately.

Why: the elog(ERROR) fix in v0.1.0 was correct in principle (unexpected non-zero codepoints should be caught) but the caller prsd2_zht2zhs was not guarding against zero returns from the table. Zero is a valid sentinel meaning 'no mapping', not an error condition.