### PR TITLE
feat: emoji token support (v0.2.0); add mixed-language and emoji tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ COPY Makefile /root/parser/
 COPY pg_cjk_parser--0.0.1.sql /root/parser/
 COPY pg_cjk_parser--0.0.1--0.1.0.sql /root/parser/
 COPY pg_cjk_parser--0.1.0.sql /root/parser/
+COPY pg_cjk_parser--0.1.0--0.2.0.sql /root/parser/
+COPY pg_cjk_parser--0.2.0.sql /root/parser/
 COPY zht2zhs.h /root/parser/
 RUN make clean && make install
 
@@ -21,4 +23,6 @@ COPY --from=build /root/parser/pg_cjk_parser.so /usr/lib/postgresql/$POSTGRES_VE
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1--0.1.0.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
 COPY --from=build /root/parser/pg_cjk_parser--0.1.0.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.1.0--0.2.0.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.2.0.sql /usr/share/postgresql/$POSTGRES_VERSION/extension
 COPY --from=build /root/parser/pg_cjk_parser.control /usr/share/postgresql/$POSTGRES_VERSION/extension

--- a/Dockerfile_alpine
+++ b/Dockerfile_alpine
@@ -14,6 +14,8 @@ COPY Makefile /root/parser/
 COPY pg_cjk_parser--0.0.1.sql /root/parser/
 COPY pg_cjk_parser--0.0.1--0.1.0.sql /root/parser/
 COPY pg_cjk_parser--0.1.0.sql /root/parser/
+COPY pg_cjk_parser--0.1.0--0.2.0.sql /root/parser/
+COPY pg_cjk_parser--0.2.0.sql /root/parser/
 COPY zht2zhs.h /root/parser/
 RUN make clean && make install
 
@@ -23,4 +25,6 @@ COPY --from=build /root/parser/pg_cjk_parser.so /usr/local/lib/postgresql/
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1.sql /usr/local/share/postgresql/extension/
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1--0.1.0.sql /usr/local/share/postgresql/extension/
 COPY --from=build /root/parser/pg_cjk_parser--0.1.0.sql /usr/local/share/postgresql/extension/
+COPY --from=build /root/parser/pg_cjk_parser--0.1.0--0.2.0.sql /usr/local/share/postgresql/extension/
+COPY --from=build /root/parser/pg_cjk_parser--0.2.0.sql /usr/local/share/postgresql/extension/
 COPY --from=build /root/parser/pg_cjk_parser.control /usr/local/share/postgresql/extension/

--- a/Dockerfile_pg11
+++ b/Dockerfile_pg11
@@ -10,6 +10,8 @@ COPY Makefile /root/parser/
 COPY pg_cjk_parser--0.0.1.sql /root/parser/
 COPY pg_cjk_parser--0.0.1--0.1.0.sql /root/parser/
 COPY pg_cjk_parser--0.1.0.sql /root/parser/
+COPY pg_cjk_parser--0.1.0--0.2.0.sql /root/parser/
+COPY pg_cjk_parser--0.2.0.sql /root/parser/
 COPY zht2zhs.h /root/parser/
 RUN make clean && make install
 
@@ -19,4 +21,6 @@ COPY --from=build /root/parser/pg_cjk_parser.so /usr/local/lib/postgresql
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1.sql /usr/local/share/postgresql/extension
 COPY --from=build /root/parser/pg_cjk_parser--0.0.1--0.1.0.sql /usr/local/share/postgresql/extension
 COPY --from=build /root/parser/pg_cjk_parser--0.1.0.sql /usr/local/share/postgresql/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.1.0--0.2.0.sql /usr/local/share/postgresql/extension
+COPY --from=build /root/parser/pg_cjk_parser--0.2.0.sql /usr/local/share/postgresql/extension
 COPY --from=build /root/parser/pg_cjk_parser.control /usr/local/share/postgresql/extension

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MODULES = pg_cjk_parser
 EXTENSION = pg_cjk_parser
-DATA = pg_cjk_parser--0.0.1.sql pg_cjk_parser--0.0.1--0.1.0.sql pg_cjk_parser--0.1.0.sql
+DATA = pg_cjk_parser--0.0.1.sql pg_cjk_parser--0.0.1--0.1.0.sql pg_cjk_parser--0.1.0.sql pg_cjk_parser--0.1.0--0.2.0.sql pg_cjk_parser--0.2.0.sql
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)

--- a/pg_cjk_parser--0.1.0--0.2.0.sql
+++ b/pg_cjk_parser--0.1.0--0.2.0.sql
@@ -1,0 +1,5 @@
+-- pg_cjk_parser upgrade: 0.1.0 -> 0.2.0
+-- Adds emoji token type (alias: "emoji") to the parser.
+-- To index emoji in your text search configuration:
+--   ALTER TEXT SEARCH CONFIGURATION <your_config>
+--     ADD MAPPING FOR emoji WITH simple;

--- a/pg_cjk_parser--0.2.0.sql
+++ b/pg_cjk_parser--0.2.0.sql
@@ -1,0 +1,47 @@
+--
+--
+\echo Use "CREATE EXTENSION pg_cjk_parser" to load this file. \quit
+
+CREATE FUNCTION public.prsd2_cjk_start(IN internal, IN integer)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_start'
+;
+
+
+CREATE FUNCTION public.prsd2_cjk_nexttoken(IN internal, IN internal, IN internal)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_nexttoken'
+;
+
+	
+CREATE FUNCTION public.prsd2_cjk_end(IN internal)
+    RETURNS void
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_end'
+;
+
+CREATE FUNCTION public.prsd2_cjk_lextype(IN internal)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_lextype'
+;
+
+CREATE FUNCTION public.prsd2_cjk_headline(IN internal, IN internal, IN tsquery)
+    RETURNS internal
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_headline'
+;
+
+CREATE FUNCTION public.cjk_zht2zhs(IN text)
+    RETURNS text
+    LANGUAGE 'c' STRICT
+    
+AS 'MODULE_PATHNAME', 'prsd2_zht2zhs'
+;

--- a/pg_cjk_parser.c
+++ b/pg_cjk_parser.c
@@ -84,8 +84,9 @@ PG_FUNCTION_INFO_V1(prsd2_lextype);
 #define UNSIGNEDINT		22
 #define XMLENTITY		23
 #define CJK_CHAR		24
+#define EMOJI_T			25
 
-#define LASTNUM			24
+#define LASTNUM			25
 
 static const char *const tok_alias[] = {
 	"",
@@ -112,7 +113,8 @@ static const char *const tok_alias[] = {
 	"int",
 	"uint",
 	"entity",
-	"cjk"
+	"cjk",
+	"emoji"
 };
 
 static const char *const lex_descr[] = {
@@ -140,7 +142,8 @@ static const char *const lex_descr[] = {
 	"Signed integer",
 	"Unsigned integer",
 	"XML entity",
-	"CJK Char"
+	"CJK Char",
+	"Emoji symbol"
 };
 
 
@@ -226,6 +229,7 @@ typedef enum
 	TPS_InHyphenNumWordPart,
 	TPS_InHyphenUnsignedInt,
 	TPS_InCJK,
+	TPS_InEmoji,
 	TPS_Null					/* last state (fake value) */
 } TParserState;
 
@@ -962,6 +966,32 @@ p_isCJKunigram(TParser *prs)
 	return 0;
 }
 
+static int
+p_isEmoji(TParser *prs)
+{
+	if (GetDatabaseEncoding() == PG_UTF8 && prs->usewide)
+	{
+		pg_wchar	c;
+
+		if (prs->pgwstr)
+			c = *(prs->pgwstr + prs->state->poschar);
+		else
+			c = (pg_wchar) *(prs->wstr + prs->state->poschar);
+
+		/* Miscellaneous Symbols and Dingbats (3-byte UTF-8) */
+		if (c >= 0x2600 && c <= 0x27BF)
+			return 1;
+
+		/*
+		 * Emoji proper: Misc Symbols & Pictographs, Emoticons, Transport,
+		 * Supplemental Symbols, and related blocks (4-byte UTF-8).
+		 */
+		if (c >= 0x1F300 && c <= 0x1FAFF)
+			return 1;
+	}
+	return 0;
+}
+
 /* deliberately suppress unused-function complaints for the above */
 void		_make_compiler_happy(void);
 void
@@ -994,6 +1024,7 @@ _make_compiler_happy(void)
 	p_isCJKunigram(NULL);
 	p_isCJK(NULL);
 	p_isnotCJK(NULL);
+	p_isEmoji(NULL);
 }
 
 
@@ -1393,9 +1424,15 @@ p_isspecial(TParser *prs)
  * Table of state/action of parser
  */
 
+static const TParserStateActionItem actionTPS_InEmoji[] = {
+	{p_isEOF, 0, A_BINGO, TPS_Base, EMOJI_T, NULL},
+	{NULL, 0, A_BINGO, TPS_Base, EMOJI_T, NULL}
+};
+
 static const TParserStateActionItem actionTPS_Base[] = {
 	{p_isEOF, 0, A_NEXT, TPS_Null, 0, NULL},
-	{p_isCJK, 0, A_NEXT, TPS_InCJK, 0, NULL}, 
+	{p_isCJK, 0, A_NEXT, TPS_InCJK, 0, NULL},
+	{p_isEmoji, 0, A_NEXT, TPS_InEmoji, 0, NULL},
 	{p_iseqC, '<', A_PUSH, TPS_InTagFirst, 0, NULL},
 	{p_isignore, 0, A_NEXT, TPS_InSpace, 0, NULL},
 	{p_isasclet, 0, A_NEXT, TPS_InAsciiWord, 0, NULL},
@@ -2140,6 +2177,7 @@ static const TParserStateAction Actions[] = {
 	TPARSERSTATEACTION(TPS_InHyphenNumWordPart),
 	TPARSERSTATEACTION(TPS_InHyphenUnsignedInt),
 	TPARSERSTATEACTION(TPS_InCJK),
+	TPARSERSTATEACTION(TPS_InEmoji),
 };
 
 

--- a/pg_cjk_parser.control
+++ b/pg_cjk_parser.control
@@ -1,4 +1,4 @@
 comment = 'A token parser derived from pg default parser that parses CJK into 2-gram'
-default_version = '0.1.0'
+default_version = '0.2.0'
 module_pathname = '$libdir/pg_cjk_parser'
 relocatable = true

--- a/postgres-11.sh
+++ b/postgres-11.sh
@@ -56,6 +56,7 @@ docker exec postgres11 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION publ
 docker exec postgres11 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR version WITH simple;"
 
 docker exec postgres11 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR word WITH simple;"
+docker exec postgres11 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR emoji WITH simple;"
 
 OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多拉A梦 野比大雄χΨψΩω'), to_tsquery('のび太'), to_tsquery('野比大雄');")
 echo $OUTPUT
@@ -138,7 +139,7 @@ then
 fi
 
 # Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
-OUTPUT=$(docker exec postgres11 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.2.0';")
 echo $OUTPUT
 if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
 then
@@ -158,6 +159,130 @@ then
     echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
     docker stop postgres11 && docker rm postgres11
     exit 1
+fi
+
+
+# --- Mixed language and emoji tests ---
+
+# French (2-byte UTF-8) before Traditional Chinese
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('café漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"café汉语"* ]]; then
+    echo "cjk_zht2zhs: French chars before CJK failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Traditional Chinese around French
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('漢語café漢');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉语café汉"* ]]; then
+    echo "cjk_zht2zhs: French chars between CJK failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Emoji (4-byte) before Traditional Chinese
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('😀漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"😀汉语"* ]]; then
+    echo "cjk_zht2zhs: emoji before CJK failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Traditional Chinese around emoji
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('漢😀語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉😀语"* ]]; then
+    echo "cjk_zht2zhs: emoji between CJK failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Pure ASCII must be returned unchanged
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('hello world') = 'hello world';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: pure ASCII not returned unchanged"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Empty string must not crash
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SELECT cjk_zht2zhs('') = '';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: empty string failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Single CJK character must emit as unigram (not dropped)
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你'"* ]]; then
+    echo "tokenizer: single CJK character not emitted as unigram"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Two CJK characters must produce exactly one 2-gram
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]]; then
+    echo "tokenizer: two CJK chars did not produce 2-gram"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# English + Chinese: ASCII words and CJK 2-grams coexist
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('hello 你好世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'好世'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: English + Chinese mixed tokenization failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# French + Japanese: non-ASCII Latin and CJK coexist
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('café 東京 bonjour');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'東京'"* ]] || [[ "$OUTPUT" != *"'café'"* ]]; then
+    echo "tokenizer: French + Japanese mixed tokenization failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# CJK + emoji + CJK: emoji tokenized, CJK 2-grams unaffected
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# CJK adjacent to ASCII with no spaces
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('abc你好def');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'abc'"* ]] || [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'def'"* ]]; then
+    echo "tokenizer: CJK adjacent to ASCII (no spaces) failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+
+# Emoji is tokenized as its own 'emoji' token type (always unigram, never n-gram)
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]]; then
+    echo "tokenizer: emoji not indexed as emoji token type"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Emoji between CJK chars: CJK 2-grams and emoji are all indexed
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres11 && docker rm postgres11; exit 1
+fi
+
+# Multiple emoji: each is a separate token
+OUTPUT=$(docker exec postgres11 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀🔥');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'🔥'"* ]]; then
+    echo "tokenizer: consecutive emoji not tokenized as separate tokens"
+    docker stop postgres11 && docker rm postgres11; exit 1
 fi
 
 docker stop postgres11 && docker rm postgres11

--- a/postgres-12.sh
+++ b/postgres-12.sh
@@ -56,6 +56,7 @@ docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION publ
 docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR version WITH simple;"
 
 docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR word WITH simple;"
+docker exec postgres12 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR emoji WITH simple;"
 
 OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多拉A梦 野比大雄χΨψΩω'), to_tsquery('のび太'), to_tsquery('野比大雄');")
 echo $OUTPUT
@@ -138,7 +139,7 @@ then
 fi
 
 # Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
-OUTPUT=$(docker exec postgres12 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.2.0';")
 echo $OUTPUT
 if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
 then
@@ -158,6 +159,130 @@ then
     echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
     docker stop postgres12 && docker rm postgres12
     exit 1
+fi
+
+
+# --- Mixed language and emoji tests ---
+
+# French (2-byte UTF-8) before Traditional Chinese
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('café漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"café汉语"* ]]; then
+    echo "cjk_zht2zhs: French chars before CJK failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Traditional Chinese around French
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('漢語café漢');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉语café汉"* ]]; then
+    echo "cjk_zht2zhs: French chars between CJK failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Emoji (4-byte) before Traditional Chinese
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('😀漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"😀汉语"* ]]; then
+    echo "cjk_zht2zhs: emoji before CJK failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Traditional Chinese around emoji
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('漢😀語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉😀语"* ]]; then
+    echo "cjk_zht2zhs: emoji between CJK failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Pure ASCII must be returned unchanged
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('hello world') = 'hello world';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: pure ASCII not returned unchanged"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Empty string must not crash
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SELECT cjk_zht2zhs('') = '';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: empty string failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Single CJK character must emit as unigram (not dropped)
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你'"* ]]; then
+    echo "tokenizer: single CJK character not emitted as unigram"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Two CJK characters must produce exactly one 2-gram
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]]; then
+    echo "tokenizer: two CJK chars did not produce 2-gram"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# English + Chinese: ASCII words and CJK 2-grams coexist
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('hello 你好世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'好世'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: English + Chinese mixed tokenization failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# French + Japanese: non-ASCII Latin and CJK coexist
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('café 東京 bonjour');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'東京'"* ]] || [[ "$OUTPUT" != *"'café'"* ]]; then
+    echo "tokenizer: French + Japanese mixed tokenization failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# CJK + emoji + CJK: emoji tokenized, CJK 2-grams unaffected
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# CJK adjacent to ASCII with no spaces
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('abc你好def');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'abc'"* ]] || [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'def'"* ]]; then
+    echo "tokenizer: CJK adjacent to ASCII (no spaces) failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+
+# Emoji is tokenized as its own 'emoji' token type (always unigram, never n-gram)
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]]; then
+    echo "tokenizer: emoji not indexed as emoji token type"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Emoji between CJK chars: CJK 2-grams and emoji are all indexed
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres12 && docker rm postgres12; exit 1
+fi
+
+# Multiple emoji: each is a separate token
+OUTPUT=$(docker exec postgres12 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀🔥');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'🔥'"* ]]; then
+    echo "tokenizer: consecutive emoji not tokenized as separate tokens"
+    docker stop postgres12 && docker rm postgres12; exit 1
 fi
 
 docker stop postgres12 && docker rm postgres12

--- a/postgres-16.sh
+++ b/postgres-16.sh
@@ -56,6 +56,7 @@ docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION publ
 docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR version WITH simple;"
 
 docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR word WITH simple;"
+docker exec postgres16 psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR emoji WITH simple;"
 
 OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多拉A梦 野比大雄χΨψΩω'), to_tsquery('のび太'), to_tsquery('野比大雄');")
 echo $OUTPUT
@@ -138,7 +139,7 @@ then
 fi
 
 # Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
-OUTPUT=$(docker exec postgres16 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.2.0';")
 echo $OUTPUT
 if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
 then
@@ -158,6 +159,131 @@ then
     echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
     docker stop postgres16 && docker rm postgres16
     exit 1
+fi
+
+
+# --- Mixed language and emoji tests ---
+
+# French (2-byte UTF-8) before Traditional Chinese
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('café漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"café汉语"* ]]; then
+    echo "cjk_zht2zhs: French chars before CJK failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Traditional Chinese around French
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('漢語café漢');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉语café汉"* ]]; then
+    echo "cjk_zht2zhs: French chars between CJK failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Emoji (4-byte) before Traditional Chinese
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('😀漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"😀汉语"* ]]; then
+    echo "cjk_zht2zhs: emoji before CJK failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Traditional Chinese around emoji
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('漢😀語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉😀语"* ]]; then
+    echo "cjk_zht2zhs: emoji between CJK failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Pure ASCII must be returned unchanged
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('hello world') = 'hello world';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: pure ASCII not returned unchanged"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Empty string must not crash
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SELECT cjk_zht2zhs('') = '';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: empty string failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Single CJK character must emit as unigram (not dropped)
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你'"* ]]; then
+    echo "tokenizer: single CJK character not emitted as unigram"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Two CJK characters must produce exactly one 2-gram
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]]; then
+    echo "tokenizer: two CJK chars did not produce 2-gram"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# English + Chinese: ASCII words and CJK 2-grams coexist
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('hello 你好世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'好世'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: English + Chinese mixed tokenization failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# French + Japanese: non-ASCII Latin and CJK coexist
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('café 東京 bonjour');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'東京'"* ]] || [[ "$OUTPUT" != *"'café'"* ]]; then
+    echo "tokenizer: French + Japanese mixed tokenization failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# CJK + emoji + CJK: emoji is classified as blank (not indexed by default),
+# but CJK 2-grams on both sides must survive
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# CJK adjacent to ASCII with no spaces
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('abc你好def');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'abc'"* ]] || [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'def'"* ]]; then
+    echo "tokenizer: CJK adjacent to ASCII (no spaces) failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+
+# Emoji is tokenized as its own 'emoji' token type (always unigram, never n-gram)
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]]; then
+    echo "tokenizer: emoji not indexed as emoji token type"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Emoji between CJK chars: CJK 2-grams and emoji are all indexed
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres16 && docker rm postgres16; exit 1
+fi
+
+# Multiple emoji: each is a separate token
+OUTPUT=$(docker exec postgres16 psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀🔥');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'🔥'"* ]]; then
+    echo "tokenizer: consecutive emoji not tokenized as separate tokens"
+    docker stop postgres16 && docker rm postgres16; exit 1
 fi
 
 docker stop postgres16 && docker rm postgres16

--- a/postgres-1x.sh
+++ b/postgres-1x.sh
@@ -56,6 +56,7 @@ docker exec postgres_db psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION pub
 docker exec postgres_db psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR version WITH simple;"
 
 docker exec postgres_db psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR word WITH simple;"
+docker exec postgres_db psql -U postgres -c "ALTER TEXT SEARCH CONFIGURATION public.config_2_gram_cjk ADD MAPPING FOR emoji WITH simple;"
 
 OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config = 'public.config_2_gram_cjk'; SELECT to_tsvector('Doraemnon Nobita「ドラえもん のび太の牧場物語」多拉A梦 野比大雄χΨψΩω'), to_tsquery('のび太'), to_tsquery('野比大雄');")
 echo $OUTPUT
@@ -138,7 +139,7 @@ then
 fi
 
 # Test upgrade path: ALTER EXTENSION UPDATE must succeed (requires upgrade SQL script in image)
-OUTPUT=$(docker exec postgres_db psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.1.0';")
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "ALTER EXTENSION pg_cjk_parser UPDATE TO '0.2.0';")
 echo $OUTPUT
 if [[ "$OUTPUT" != "ALTER EXTENSION" ]];
 then
@@ -158,6 +159,130 @@ then
     echo "cjk_zht2zhs: character with no simplified form should be returned unchanged"
     docker stop postgres_db && docker rm postgres_db
     exit 1
+fi
+
+
+# --- Mixed language and emoji tests ---
+
+# French (2-byte UTF-8) before Traditional Chinese
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('café漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"café汉语"* ]]; then
+    echo "cjk_zht2zhs: French chars before CJK failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Traditional Chinese around French
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('漢語café漢');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉语café汉"* ]]; then
+    echo "cjk_zht2zhs: French chars between CJK failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Emoji (4-byte) before Traditional Chinese
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('😀漢語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"😀汉语"* ]]; then
+    echo "cjk_zht2zhs: emoji before CJK failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Traditional Chinese around emoji
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('漢😀語');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"汉😀语"* ]]; then
+    echo "cjk_zht2zhs: emoji between CJK failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Pure ASCII must be returned unchanged
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('hello world') = 'hello world';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: pure ASCII not returned unchanged"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Empty string must not crash
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SELECT cjk_zht2zhs('') = '';")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"t"* ]]; then
+    echo "cjk_zht2zhs: empty string failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Single CJK character must emit as unigram (not dropped)
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你'"* ]]; then
+    echo "tokenizer: single CJK character not emitted as unigram"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Two CJK characters must produce exactly one 2-gram
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]]; then
+    echo "tokenizer: two CJK chars did not produce 2-gram"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# English + Chinese: ASCII words and CJK 2-grams coexist
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('hello 你好世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'好世'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: English + Chinese mixed tokenization failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# French + Japanese: non-ASCII Latin and CJK coexist
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('café 東京 bonjour');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'東京'"* ]] || [[ "$OUTPUT" != *"'café'"* ]]; then
+    echo "tokenizer: French + Japanese mixed tokenization failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# CJK + emoji + CJK: emoji tokenized, CJK 2-grams unaffected
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# CJK adjacent to ASCII with no spaces
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('abc你好def');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'abc'"* ]] || [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'def'"* ]]; then
+    echo "tokenizer: CJK adjacent to ASCII (no spaces) failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+
+# Emoji is tokenized as its own 'emoji' token type (always unigram, never n-gram)
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]]; then
+    echo "tokenizer: emoji not indexed as emoji token type"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Emoji between CJK chars: CJK 2-grams and emoji are all indexed
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('你好😀世界');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'你好'"* ]] || [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'世界'"* ]]; then
+    echo "tokenizer: CJK + emoji + CJK tokenization failed"
+    docker stop postgres_db && docker rm postgres_db; exit 1
+fi
+
+# Multiple emoji: each is a separate token
+OUTPUT=$(docker exec postgres_db psql -U postgres -c "SET default_text_search_config='public.config_2_gram_cjk'; SELECT to_tsvector('😀🔥');")
+echo $OUTPUT
+if [[ "$OUTPUT" != *"'😀'"* ]] || [[ "$OUTPUT" != *"'🔥'"* ]]; then
+    echo "tokenizer: consecutive emoji not tokenized as separate tokens"
+    docker stop postgres_db && docker rm postgres_db; exit 1
 fi
 
 docker stop postgres_db && docker rm postgres_db


### PR DESCRIPTION
What:

Add emoji token type to the parser (type 25, alias 'emoji'). Emoji are always tokenized as unigrams — there is no 2-gram sliding window for emoji because adjacent emoji are independent symbols, not compound units.

Implementation:
- p_isEmoji(): checks for Miscellaneous Symbols/Dingbats (U+2600-U+27BF, 3-byte UTF-8) and the main emoji blocks (U+1F300-U+1FAFF, 4-byte UTF-8)
- TPS_InEmoji state with actionTPS_InEmoji: immediately BINGO, same pattern as TPS_InCJK
- p_isEmoji added to actionTPS_Base before the catch-all, so emoji no longer falls through to blank/space
- EMOJI_T token type (25) added to tok_alias and lex_descr arrays
- LASTNUM bumped from 24 to 25

Users who want emoji indexed add one mapping to their config:
  ALTER TEXT SEARCH CONFIGURATION <cfg> ADD MAPPING FOR emoji WITH simple;

Version bump to 0.2.0 with upgrade script pg_cjk_parser--0.1.0--0.2.0.sql.

Also added 12 mixed-language and emoji test cases across all CI scripts:
- cjk_zht2zhs with French (2-byte), emoji (4-byte), ASCII, empty string
- Tokenizer: single CJK unigram, two-char 2-gram, EN+ZH, FR+JP, ZH+emoji+ZH, ASCII+ZH+ASCII, standalone emoji, consecutive emoji

Why:

Emoji were classified as blank (Space symbols) because no parser state handled them — they fell through the actionTPS_Base catch-all. This meant emoji in user content were silently dropped from tsvector and could never be matched by tsquery. With emoji being first-class tokens, searches for 😀 or 🔥 now work as expected.